### PR TITLE
use addModule to prevent duplication error in import

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,10 +4,9 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const verkle_crypto_module = b.createModule(.{
-        .root_source_file = .{ .cwd_relative = "src/main.zig" },
+    _ = b.addModule("verkle-crypto", .{
+        .root_source_file = b.path("src/main.zig"),
     });
-    try b.modules.put(b.dupe("verkle-crypto"), verkle_crypto_module);
 
     const lib = b.addStaticLibrary(.{
         .name = "verkle-crypto",


### PR DESCRIPTION
The former way now creates two references to the module when importing it, and so the import fails in `zig-verkle`. With this change, only one module reference is found.